### PR TITLE
Move 'hastscript' to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lang"
   ],
   "dependencies": {
-    "prismjs": "~1.6.0"
+    "prismjs": "~1.6.0",
+    "hastscript": "^3.1.0"
   },
   "devDependencies": {
     "alpha-sort": "^2.0.1",
@@ -37,7 +38,6 @@
     "chalk": "^2.0.0",
     "detab": "^2.0.0",
     "esmangle": "^1.0.0",
-    "hastscript": "^3.1.0",
     "is-hidden": "^1.1.0",
     "mdast-zone": "^3.0.1",
     "not": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "lang"
   ],
   "dependencies": {
-    "prismjs": "~1.6.0",
-    "hastscript": "^3.1.0"
+    "hastscript": "^3.1.0",
+    "prismjs": "~1.6.0"
   },
   "devDependencies": {
     "alpha-sort": "^2.0.1",


### PR DESCRIPTION
Fix `Can't resolve 'hastscript' ` error. 

I've tested it by installing only the production dependencies with `yarn install --production` and then linking to it with `yarn link` in a demo project.

Closes #1