### PR TITLE
[WIP] don't use Prism's default behavior in browser

### DIFF
--- a/core.js
+++ b/core.js
@@ -13,6 +13,8 @@ var css = require('./lang/css');
 var clike = require('./lang/clike');
 var js = require('./lang/javascript');
 
+Prism.manual = true;
+
 restore();
 
 var own = {}.hasOwnProperty;

--- a/core.js
+++ b/core.js
@@ -2,6 +2,11 @@
 
 var restore = capture();
 
+/* Don't allow Prism to run on page load. */
+if (typeof window !== 'undefined') {
+  window.Prism = {manual: true};
+}
+
 /* Load all stuff in `prism.js` itself, except for
  * `prism-file-highlight.js`.
  * The wrapped non-leaky grammars are loaded instead of
@@ -12,8 +17,6 @@ var markup = require('./lang/markup');
 var css = require('./lang/css');
 var clike = require('./lang/clike');
 var js = require('./lang/javascript');
-
-Prism.manual = true;
 
 restore();
 

--- a/core.js
+++ b/core.js
@@ -3,9 +3,14 @@
 var restore = capture();
 
 /* Don't allow Prism to run on page load. */
-if (typeof window !== 'undefined') {
-  window.Prism = {manual: true};
-}
+/* eslint-disable no-negated-condition */
+/* global window, WorkerGlobalScope, self */
+/* istanbul ignore next */
+var _self = (typeof window !== 'undefined') ? window : (
+  (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : {}
+);
+/* eslint-enable no-negated-condition */
+_self.Prism = {manual: true};
 
 /* Load all stuff in `prism.js` itself, except for
  * `prism-file-highlight.js`.


### PR DESCRIPTION
Prism by default will run `highlightAll` when loaded in the browser. Setting it to `manual` will fix this.