### PR TITLE
Add listLanguages method to refractor

### DIFF
--- a/core.js
+++ b/core.js
@@ -38,6 +38,8 @@ Refractor.prototype = Prism
 
 /* Construct. */
 var refract = new Refractor()
+var languageMethods = new Set(Object.keys(refract.languages))
+var registeredLanguages = new Set()
 
 /* Expose. */
 module.exports = refract
@@ -46,6 +48,7 @@ module.exports = refract
 refract.highlight = highlight
 refract.register = register
 refract.registered = registered
+refract.listLanguages = listLanguages
 
 /* Register bundled grammars. */
 register(markup)
@@ -64,6 +67,13 @@ function register(grammar) {
   /* Do not duplicate registrations. */
   if (refract.languages[grammar.displayName] === undefined) {
     grammar(refract)
+
+    /* Ensure that any languages added to the instance are known */
+    for (var language in refract.languages) {
+      if (!isLanguageMethod(language)) {
+        registeredLanguages.add(language)
+      }
+    }
   }
 }
 
@@ -100,6 +110,15 @@ function registered(language) {
   }
 
   return own.call(refract.languages, language)
+}
+
+/* Returns the list of all languages that have been registered through the `register` function. */
+function listLanguages() {
+  return [...registeredLanguages]
+}
+
+function isLanguageMethod(name) {
+  return languageMethods.has(name)
 }
 
 function stringify(value, language, parent) {

--- a/test/index.js
+++ b/test/index.js
@@ -225,3 +225,38 @@ test('fixtures', function(t) {
 
   t.end()
 })
+
+test('listLanguages', function(t) {
+  var expectedLanguages = Object.keys(Prism.languages).filter(
+    lang => typeof Prism.languages[lang] !== 'function'
+  )
+
+  t.deepEqual(
+    refractor
+      .listLanguages()
+      .concat()
+      .sort(),
+    expectedLanguages.concat().sort(),
+    'should return the same list of languages as prismjs'
+  )
+
+  var testGrammar = '--test-grammar-314159--'
+  var testLang1 = '--test-lang-1414--'
+  var testLang2 = '--test-lang-0707--'
+  var mockGrammar = function(p) {
+    p.languages[testLang1] = {}
+    p.languages[testLang2] = {}
+  }
+  mockGrammar.displayName = testGrammar
+  refractor.register(mockGrammar)
+  t.ok(
+    refractor.listLanguages().includes(testLang1),
+    'should include any additional languages from registered grammars (test lang 1)'
+  )
+  t.ok(
+    refractor.listLanguages().includes(testLang2),
+    'should include any additional languages from registered grammars (test lang 2)'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
This is a little hacky because Prism doesn't keep an explicit list of languages, and languages aren't
registered directly (a grammar is registered, which can arbitrarily modify the languages collection).
Instead, prism has an object that it uses to track its languages, but that object also has methods
attached to it, so its own properties include both languages and methods.