### PR TITLE
Add sh as bash alias

### DIFF
--- a/lang/bash.js
+++ b/lang/bash.js
@@ -2,7 +2,7 @@
 
 module.exports = bash
 bash.displayName = 'bash'
-bash.aliases = ['shell']
+bash.aliases = ['shell', 'sh']
 function bash(Prism) {
   ;(function(Prism) {
     var insideString = {


### PR DESCRIPTION
Hello,

I added `sh` as `bash` alias since it's widely used (e.g. GitHub highlighter use it)