### PR TITLE
Quantifier has nothing to repeat fix.

### DIFF
--- a/lang/soy.js
+++ b/lang/soy.js
@@ -38,7 +38,7 @@ function soy(Prism) {
         /\b(?:any|as|attributes|bool|css|float|in|int|js|html|list|map|null|number|string|uri)\b/
       ],
       delimiter: {
-        pattern: /^{+\/?|\/?}+$/,
+        pattern: /^\{+\/?|\/?}+$/,
         alias: 'punctuation'
       },
       property: /\w+(?==)/,


### PR DESCRIPTION
Hi all!
while developing and updating the dependencies of my React Native application (Glasnost), a Gitlab mobile client, the library [react-native-syntax-highlighter](https://github.com/conorhastings/react-native-syntax-highlighter) introduced a very annoying issue that resulted in a crash when updating the android dependencies to handle Android X.  
react-native-syntax-highlighter uses react-syntax-highlighter and the last module is using Refractor.  
Something in some very low dependency in android has some serious issue that results in bad regex parsing. And the solution is to add some more escapes into the "broken" regex.
This Pull Request is exactly about solving one of those.

Kind regards and thanks!