### PR TITLE
GraphQL lang: add "description" (triple-quoted docstring) regex

### DIFF
--- a/lang/graphql.js
+++ b/lang/graphql.js
@@ -10,6 +10,10 @@ function graphql(Prism) {
       pattern: /"(?:\\.|[^\\"\r\n])*"/,
       greedy: true
     },
+    docstring: {
+      pattern: /(\s{4})?(\"{3}((?!\"\"\")[^\\]|\\[abfnrtv?\"'\\0-7]|\\x[0-9a-fA-F])*\"{3})$/gm,
+      greedy: true
+    },
     number: /(?:\B-|\b)\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
     boolean: /\b(?:true|false)\b/,
     variable: /\$[a-z_]\w*/i,


### PR DESCRIPTION
Triple-quoted [docstrings are valid in GraphQL](https://www.apollographql.com/docs/resources/graphql-glossary/#docstring), but are missing from the language definition here in refractor.

Prism refers to these as `description` rather than `docstring`, so I've adopted the same token name here.