### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,11 +256,11 @@ Yields:
 It is not suggested to import `refractor` itself in the browser as that would
 include a 500kb (187kb minzipped) of code.
 
-Instead import `refractor/core.js` and include only the needed syntaxes.
+Instead import `refractor/lib/core.js` and include only the needed syntaxes.
 For example:
 
 ```js
-import {refractor} from 'refractor/core.js'
+import {refractor} from 'refractor/lib/core';
 import jsx from 'refractor/lang/jsx.js'
 
 refractor.register(jsx)

--- a/readme.md
+++ b/readme.md
@@ -260,7 +260,7 @@ Instead import `refractor/lib/core.js` and include only the needed syntaxes.
 For example:
 
 ```js
-import {refractor} from 'refractor/lib/core';
+import {refractor} from 'refractor/lib/core.js';
 import jsx from 'refractor/lang/jsx.js'
 
 refractor.register(jsx)


### PR DESCRIPTION
I've updated the README as it seems that the `core.js` file is now located under `/lib`