### PR TITLE
Add `proto` alias for protobuf

### DIFF
--- a/lang/protobuf.js
+++ b/lang/protobuf.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import refractorClike from './clike.js'
 protobuf.displayName = 'protobuf'
-protobuf.aliases = []
+protobuf.aliases = ['proto']
 
 /** @type {import('../core.js').Syntax} */
 export default function protobuf(Prism) {

--- a/readme.md
+++ b/readme.md
@@ -597,7 +597,7 @@ syntaxes are made to work with global variables and are not importable.
 *   [ ] [`prolog`](https://github.com/wooorm/refractor/blob/main/lang/prolog.js)
 *   [ ] [`promql`](https://github.com/wooorm/refractor/blob/main/lang/promql.js)
 *   [ ] [`properties`](https://github.com/wooorm/refractor/blob/main/lang/properties.js)
-*   [ ] [`protobuf`](https://github.com/wooorm/refractor/blob/main/lang/protobuf.js)
+*   [ ] [`protobuf`](https://github.com/wooorm/refractor/blob/main/lang/protobuf.js) — alias: `proto`
 *   [ ] [`psl`](https://github.com/wooorm/refractor/blob/main/lang/psl.js)
 *   [ ] [`pug`](https://github.com/wooorm/refractor/blob/main/lang/pug.js)
 *   [ ] [`puppet`](https://github.com/wooorm/refractor/blob/main/lang/puppet.js)


### PR DESCRIPTION
proto is the extension for protobuf files, and is used in [other](https://github.com/shikijs/shiki/blob/44b9b0c458744267d824a8283eac4d6393f65013/packages/shiki/src/languages.ts#L104) syntax highlighters as the language id.