### PR TITLE
Allow % to be escaped for LaTeX

### DIFF
--- a/lang/latex.js
+++ b/lang/latex.js
@@ -13,7 +13,7 @@ export default function latex(Prism) {
       }
     }
     Prism.languages.latex = {
-      comment: /%.*/,
+      comment: /(?<!\\)%.*/,
       // the verbatim environment prints whitespace to the document
       cdata: {
         pattern:


### PR DESCRIPTION
`%` can be escaped with `\%` which prevents it from being a comment. https://latex-programming.fandom.com/wiki/%25_(LaTeX_symbol)