### PR TITLE
Update crystal.js with alias 'cr'

### DIFF
--- a/lang/crystal.js
+++ b/lang/crystal.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import refractorRuby from './ruby.js'
 crystal.displayName = 'crystal'
-crystal.aliases = []
+crystal.aliases = ['cr']
 
 /** @type {import('../core.js').Syntax} */
 export default function crystal(Prism) {


### PR DESCRIPTION
Currently using Prism for code highlighting and the filename extension is used instead of the language name. Files for the Crystal programming language named with the extension `.cr` (e.g. `example.cr`) are not recognized in my project because `cr` is not in the aliases and I would have to manually hardcode `crystal` (after detecting the `.cr` extension).

This PR adds the alias `cr` so it will map back to `crystal` language.

For reference, compare with Highlight.js (they have the alias): https://github.com/highlightjs/highlight.js/blob/0d7061cd0b098c3a9ecda98163111f4a23aaa2f6/src/languages/crystal.js#L306