### PR TITLE
Fix non-impactful CodeQL warning on string replacement

### DIFF
--- a/lang/mongodb.js
+++ b/lang/mongodb.js
@@ -269,7 +269,7 @@ export default function mongodb(Prism) {
       'UUID'
     ]
     operators = operators.map(function (operator) {
-      return operator.replace('$', '\\$')
+      return operator.replace(/\$/g, '\\$')
     })
     var operatorsSource = '(?:' + operators.join('|') + ')\\b'
     Prism.languages.mongodb = Prism.languages.extend('javascript', {})


### PR DESCRIPTION
CodeQL reported: "This replaces only the first occurrence of '$'." As the list of operators is hardcoded, this warning is not relevant, but a small adjustment resolves it cleanly.